### PR TITLE
feat: add pyproject.toml manifest and simplify plugin init

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,13 +1,11 @@
 from .router import router
-import logging
 from .classifier import classifier
+import logging
 
 logger = logging.getLogger("coffeebreak.activity-classification")
 
-NAME = "Activity Classification Plugin"
-DESCRIPTION = "A plugin for classifying activities in a conference or event setting."
 
-async def register_plugin():    
+async def REGISTER():
     try:
         classifier.initialize()
         logger.debug("Activity classification plugin registered.")
@@ -15,10 +13,6 @@ async def register_plugin():
         logger.error(f"Failed to register activity classification plugin: {str(e)}")
         raise
 
-async def unregister_plugin():
+
+async def UNREGISTER():
     logger.debug("Activity classification plugin unregistered.")
-
-REGISTER = register_plugin
-UNREGISTER = unregister_plugin
-
-CONFIG_PAGE = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.coffeebreak]
+identifier = "activity-classification-plugin"
+name = "Activity Classification Plugin"
+description = "A plugin for classifying activities in a conference or event setting."
+config_page = true


### PR DESCRIPTION
## Summary
- Added `pyproject.toml` with `[tool.coffeebreak]` manifest for plugin metadata
- Simplified `__init__.py` — removed metadata constants (NAME, DESCRIPTION, CONFIG_PAGE)
- Metadata is now handled by the core automatically via the manifest