### PR TITLE
chore: migrate from requirements.txt to pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Build output
+.build/

--- a/__init__.py
+++ b/__init__.py
@@ -4,11 +4,8 @@ import logging
 
 logger = logging.getLogger("coffeebreak.activity-classification")
 
-NAME = "Activity Classification Plugin"
-DESCRIPTION = "A plugin for classifying activities in a conference or event setting."
-IDENTIFIER = "activity-classification-plugin"
 
-async def register_plugin():    
+async def REGISTER():
     try:
         classifier.initialize()
         logger.debug("Activity classification plugin registered.")
@@ -17,10 +14,6 @@ async def register_plugin():
         raise
     logger.debug("Activity classification plugin registered.")
 
-async def unregister_plugin():
+
+async def UNREGISTER():
     logger.debug("Activity classification plugin unregistered.")
-
-REGISTER = register_plugin
-UNREGISTER = unregister_plugin
-
-CONFIG_PAGE = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.coffeebreak]
+identifier = "activity-classification-plugin"
+name = "Activity Classification Plugin"
+description = "A plugin for classifying activities in a conference or event setting."
+config_page = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
+[project]
+name = "activity-classification-plugin"
+version = "0.1.0"
+dependencies = [
+    "numpy==1.26.4",
+    "packaging==24.2",
+    "fsspec==2024.6.1",
+    "transformers==4.52.4",
+    "torch==2.2.2",
+]
+
 [tool.coffeebreak]
 identifier = "activity-classification-plugin"
 name = "Activity Classification Plugin"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-transformers
-torch


### PR DESCRIPTION
## Summary

- Replaces `requirements.txt` with `pyproject.toml` for dependency management
- Adds plugin metadata (`identifier`, `name`, `description`, `config_page`) under `[tool.coffeebreak]`